### PR TITLE
Added "Outdated Version" setting

### DIFF
--- a/4H-Assist/options.lua
+++ b/4H-Assist/options.lua
@@ -19,6 +19,7 @@ function ABP_4H:InitOptions()
             alpha = 0.9,
             raidLayout = nil,
             healerCCW = false,
+            outdatedVersion = "popup",
         },
         global = {
         },
@@ -65,7 +66,9 @@ function ABP_4H:InitOptions()
     end
     setupAlias("options", "opt");
     setupAlias("options", "config");
+    setupAlias("versioncheck", "v");
     setupAlias("versioncheck", "vc");
+    setupAlias("versioncheck", "version");
 
     AceConfig:RegisterOptionsTable(self:ColorizeText(addonText), {
         type = "group",
@@ -174,6 +177,19 @@ function ABP_4H:InitOptions()
                             step = 0.05,
                             get = function(info) return self.db.char.alpha; end,
                             set = function(info, v) self.db.char.alpha = v; self:RefreshMainWindow(); end,
+                        },
+                        outdatedversion = {
+                            name = "Outdated Version",
+                            order = 10,
+                            desc = "If your addon is out of date, how would you like to be notified?",
+                            type = "select",
+                            values = {
+                                popup = "Popup",
+                                msg = "Chat Message"
+                            },
+                            style = "dropdown",
+                            get = function(info) return self.db.char.outdatedVersion; end,
+                            set = function(info, v) self.db.char.outdatedVersion = v; self:RefreshMainWindow(); end,
                         },
                     },
                 },

--- a/4H-Assist/version.lua
+++ b/4H-Assist/version.lua
@@ -82,9 +82,14 @@ local function CompareVersion(versionCmp, sender)
     if not (ABP_4H:ParseVersion(version) and ABP_4H:ParseVersion(versionCmp)) then return; end
 
     if ABP_4H:VersionIsNewer(versionCmp, version) then
-        _G.StaticPopup_Show("ABP_4H_OUTDATED_VERSION",
-            ("You're running an outdated version of %s! Newer version %s discovered from %s, yours is %s. Please upgrade!"):format(
-            ABP_4H:ColorizeText("4H Assist"), ABP_4H:ColorizeText(versionCmp), ABP_4H:ColorizeName(sender), ABP_4H:ColorizeText(version)));
+        if ABP_4H:Get("outdatedVersion") == "popup" then
+            _G.StaticPopup_Show("ABP_4H_OUTDATED_VERSION",
+                ("You're running an outdated version of %s! Newer version %s discovered from %s, yours is %s. Please upgrade!"):format(
+                ABP_4H:ColorizeText("4H Assist"), ABP_4H:ColorizeText(versionCmp), ABP_4H:ColorizeName(sender), ABP_4H:ColorizeText(version)));
+        else
+            ABP_4H:Notify("Version "..versionCmp.." has been released! You are currently using v"..version..". Please update this addon from Curse/WoWInterface.");
+        end
+
         showedNagPopup = true;
     end
 end


### PR DESCRIPTION
A new option to the options panel, "Outdated Version", to allow the user to be notified via a popup or a less intrusive chat window message. This allows users to not be bombarded by update notifications in an intrusive way, while still showing them that they need to update their addon.

I also added two new aliases of versioncheck: "v", and "version", to be more intuitive.